### PR TITLE
Make RSS feed a valid XML document

### DIFF
--- a/index.php
+++ b/index.php
@@ -147,7 +147,7 @@ function rash_rss()
     $items = '';
     while($row=$res->fetch()) {
 	$title = $CONFIG['rss_url']."/?".$row['id'];
-	$desc = mangle_quote_text(htmlspecialchars($row['quote']));
+	$desc = htmlspecialchars(mangle_quote_text($row['quote']));
 	$items .= $TEMPLATE->rss_feed_item($title, $desc, $title);
     }
     print $TEMPLATE->rss_feed($CONFIG['rss_title'], $CONFIG['rss_desc'], $CONFIG['rss_url'], $items);


### PR DESCRIPTION
The problem: "\<br>" tags in quote descriptions aren't escaped, thus making XML parsers assume the tags are part of markup and not data. That makes the document invalid. Looks like this:

```xml
<item>
<title>http://nhqdb.alt.org/?2251</title>
<description>&amp;lt;Demo&amp;gt; so i heard the devteam was gonna change newt's alignment from 0<br />
&amp;lt;Demo&amp;gt; there goes newt neutrality</description>
<link>http://nhqdb.alt.org/?2251</link>
</item>
```

As one can see, the original quote is HTML-escaped twice (`<` turned into `&lt;` and then into `&amp;lt;`). First encoding protects the text from being interpreted as HTML tags; second encoding prevents the text from being interpreted as XML tags. Thus, by including "\<br>" in the second encoding, we can make the document a valid XML. The result looks like this:

```xml
<item>
<title>http://nhqdb.alt.org/?2251</title>
<description>&amp;lt;Demo&amp;gt; so i heard the devteam was gonna change newt's alignment from 0&lt;br /&gt;
&amp;lt;Demo&amp;gt; there goes newt neutrality</description>
<link>http://nhqdb.alt.org/?2251</link>
</item>
```

I have to admit I didn't actually deploy the whole Rash QDB to test this change. I used this small snippet instead:

```php
<?php

function rss_feed_item($title, $desc, $link)
{
    $str = "<item>\n";
    $str .= "<title>".$title."</title>\n";
    $str .= "<description>".$desc."</description>\n";
    $str .= "<link>".$link."</link>\n";
    $str .= "</item>\n\n";
    return $str;
}

function mangle_quote_text($txt)
{
    $txt = preg_replace('/((https?|ftp):\/\/([\w\d\-]+)(\.[\w\d\-]+){1,})([\/\?\w\d\.:=&+%~_\-]+(#[\w\d_]+)?)?/', '<A href="\\1\\5">\\1\\5</A>', $txt);
    $txt = nl2br($txt);
    return $txt;
}

$quote = '<Minoru> hi there! Check out http://nhqdb.alt.org
<someone> How are you doing today? https://nhqdb.alt.org is better IMHO';
$quote = htmlspecialchars($quote);

$title = '2109';
$desc = mangle_quote_text(htmlspecialchars($quote));

print rss_feed_item($title, $desc, $title);

?>
```

It returns the following:

```xml
<item>
<title>2109</title>
<description>&amp;lt;Minoru&amp;gt; hi there! Check out <A href="http://nhqdb.alt.org">http://nhqdb.alt.org</A><br />
&amp;lt;someone&amp;gt; How are you doing today? <A href="https://nhqdb.alt.org">https://nhqdb.alt.org</A> is better IMHO</description>
<link>2109</link>
</item>
```

and if I swap `htmlspecialchars` and `mangle_quote_text`, it returns this:

```xml
<item>
<title>2109</title>
<description>&amp;lt;Minoru&amp;gt; hi there! Check out &lt;A href=&quot;http://nhqdb.alt.org&quot;&gt;http://nhqdb.alt.org&lt;/A&gt;&lt;br /&gt;
&amp;lt;someone&amp;gt; How are you doing today? &lt;A href=&quot;https://nhqdb.alt.org&quot;&gt;https://nhqdb.alt.org&lt;/A&gt; is better IMHO</description>
<link>2109</link>
</item>
```

So seems to work as intended.

(Edited to fix the PHP code, which I mangled while copying into this PR.)