### PR TITLE
Don't show PHP errors to visitors

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,7 +1,10 @@
 <?php
 
-    error_reporting(E_ALL);
-    ini_set('display_errors','On');
+/* Same as index.php: log errors, never emit them. This matters more here --
+   a warning printed by the API lands in the middle of its own JSON. */
+error_reporting(E_ALL);
+ini_set('display_errors', 'Off');
+ini_set('log_errors', 'On');
 
 require_once('settings.php');
 require('db.php');

--- a/index.php
+++ b/index.php
@@ -1,9 +1,12 @@
 <?php
 
-//if (isset($_GET['debug'])) {
-    error_reporting(E_ALL);
-    ini_set('display_errors','On');
-//}
+/* Errors are logged, never shown to the visitor: a warning would otherwise
+   put filesystem paths and SQL fragments straight into the page. log_errors is
+   set explicitly because a number of stock builds ship it Off, where turning
+   display off on its own would discard errors rather than record them. */
+error_reporting(E_ALL);
+ini_set('display_errors', 'Off');
+ini_set('log_errors', 'On');
 
 if (!file_exists('settings.php')) {
     header("Location: install.php");


### PR DESCRIPTION
Both entry points set `display_errors` On at the top of the file, and in `index.php` the `if (isset($_GET['debug']))` guard around it is commented out. Any warning therefore puts filesystem paths and SQL fragments into the response.

In `api.php` it is worse: the warning is emitted in the middle of the JSON body, so the response stops being parseable.

`log_errors` is set in the same edit deliberately. Several stock PHP builds ship it **Off** — the `php:8.5-apache` image does — so turning display off on its own would discard errors entirely rather than record them.
