### PR TITLE
Honour $CONFIG['hostspec'] when connecting

### DIFF
--- a/db.php
+++ b/db.php
@@ -3,7 +3,7 @@
 function get_db($CONFIG, $TEMPLATE=NULL)
 {
     try {
-	$db = new PDO($CONFIG['phptype'].":host=localhost;dbname=".$CONFIG['database'], $CONFIG['username'], $CONFIG['password']);
+	$db = new PDO($CONFIG['phptype'].":host=".$CONFIG['hostspec'].";dbname=".$CONFIG['database'], $CONFIG['username'], $CONFIG['password']);
 	return $db;
     } catch (PDOException $dberror) {
 	if ($TEMPLATE) $TEMPLATE->printheader('Error');


### PR DESCRIPTION
`db.php` hardcodes `host=localhost`, so the database cannot live anywhere else.

`hostspec` is not a new setting — `settings.example.php` sets it, and `install.php` both asks for it and writes it out. It was simply never read.

One line.
