### PR TITLE
Use $_SERVER['REMOTE_ADDR'] consistently

### DIFF
--- a/util_funcs.php
+++ b/util_funcs.php
@@ -105,17 +105,17 @@ function set_voteip($salt)
 	    $hash = $arr[1];
 	    if (preg_match("/^(([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/", $addr)) {
 		if (md5($addr . $salt) != $hash)
-		    $addr = getenv("REMOTE_ADDR");
+		    $addr = $_SERVER['REMOTE_ADDR'];
 		mk_cookie('voteip', $addr . '-' . md5($addr . $salt));
 		$_SESSION['voteip'] = $addr;
 	    } else {
 		/* illegal ip in cookie */
-		$addr = getenv("REMOTE_ADDR");
+		$addr = $_SERVER['REMOTE_ADDR'];
 		mk_cookie('voteip', $addr . '-' . md5($addr . $salt));
 		$_SESSION['voteip'] = $addr;
 	    }
 	} else {
-	    $addr = getenv("REMOTE_ADDR");
+	    $addr = $_SERVER['REMOTE_ADDR'];
 	    mk_cookie('voteip', $addr . '-' . md5($addr . $salt));
 	    $_SESSION['voteip'] = $addr;
 	}


### PR DESCRIPTION
`set_voteip()` reads the client address with `getenv()` at three sites, while `index.php` uses `$_SERVER` for the same value at four.

`getenv()` reads the process environment, which mod_php populates but php-fpm and some CGI configurations do not, so those three can return `false` where the other four work.

No behaviour change under mod_php.
