### PR TITLE
Don't let request parameters override server configuration

### DIFF
--- a/api.php
+++ b/api.php
@@ -27,10 +27,16 @@ function check_cmd_auth($params)
     $writeauth = USER_NORMAL;
     $seequeue = USER_MOD;
 
-    if (isset($params['login_required']) && $params['login_required'] == 1) {
+    /* Read policy from $CONFIG, never from $params. main() builds $params as
+       array_merge($CONFIG, $_REQUEST, $_SESSION), so $_REQUEST overrides server
+       configuration -- and these two values decide who may call what. Before
+       this, `?cmd=queue&public_queue=1` was enough to get an unauthenticated
+       caller past the USER_MOD check on the moderation queue. */
+    global $CONFIG;
+    if (isset($CONFIG['login_required']) && $CONFIG['login_required'] == 1) {
         $addauth = USER_MOD;
     }
-    if (isset($params['public_queue']) && $params['public_queue'] == 1) {
+    if (isset($CONFIG['public_queue']) && $CONFIG['public_queue'] == 1) {
         $seequeue = USER_NORMAL;
     }
 


### PR DESCRIPTION
`main()` builds `$params` as `array_merge($CONFIG, $_REQUEST, $_SESSION)`, so any request parameter overrides the corresponding config value.

`check_cmd_auth()` then reads `login_required` and `public_queue` out of `$params` — and those two decide which auth level a command requires.

The effect is that appending `&public_queue=1` to an API request lowers the requirement for `queue` from `USER_MOD` to `USER_NORMAL`, letting an unauthenticated caller read the moderation queue:

```
GET /api.php?cmd=queue
    Insufficient authentication level for command "queue".  Have 4, need 3.

GET /api.php?cmd=queue&public_queue=1
    (queue contents)
```

Verified against a live install before and after the change.

Policy now comes from `$CONFIG`. Request parameters keep working for everything they are actually meant to carry — `cmd`, `qid`, `pattern` and so on.
