### PR TITLE
Set PDO error mode and fetch types explicitly

### DIFF
--- a/db.php
+++ b/db.php
@@ -3,7 +3,18 @@
 function get_db($CONFIG, $TEMPLATE=NULL)
 {
     try {
-	$db = new PDO($CONFIG['phptype'].":host=localhost;dbname=".$CONFIG['database'], $CONFIG['username'], $CONFIG['password']);
+	/* Set explicitly so behaviour does not depend on the PHP version.
+	   ERRMODE defaulted to SILENT through 7.4 and to EXCEPTION from 8.0;
+	   WARNING keeps the old control flow -- a failed call still returns
+	   false, so the many unchecked call sites behave as before -- while
+	   making failures visible in the log instead of silent.
+	   STRINGIFY_FETCHES keeps the pre-8.1 types: mysqlnd now returns native
+	   int/float for numeric columns, which changes api.php's JSON from
+	   {"napproved":"12"} to {"napproved":12}. */
+	$db = new PDO($CONFIG['phptype'].":host=localhost;dbname=".$CONFIG['database'],
+		      $CONFIG['username'], $CONFIG['password'],
+		      array(PDO::ATTR_ERRMODE => PDO::ERRMODE_WARNING,
+			    PDO::ATTR_STRINGIFY_FETCHES => true));
 	return $db;
     } catch (PDOException $dberror) {
 	if ($TEMPLATE) $TEMPLATE->printheader('Error');


### PR DESCRIPTION
Both of these changed under the application on PHP 8, so they seem worth pinning rather than inheriting.

**`ERRMODE`** was `SILENT` up to 7.4 and `EXCEPTION` from 8.0. Going straight to `EXCEPTION` turns every unchecked query — there are around seventy — into a potential uncaught exception, so `WARNING` is the conservative landing point: identical control flow, but failures reach the error log instead of vanishing silently.

**`STRINGIFY_FETCHES`** restores the pre-8.1 behaviour where numeric columns come back as strings. Without it, mysqlnd returns native int/float and the JSON `api.php` emits changes shape:

```
{"napproved":"4591"}   ->   {"napproved":4591}
[{"id":"4591", ...}]   ->   [{"id":4591, ...}]
```

That is a visible break for anything consuming the API. Happy to drop this half if you would rather take the native types deliberately — it is the one opinionated change in the set.

Note this touches the same line as #3, if both are taken.
