### PR TITLE
Fix PHP 8 compatibility

### DIFF
--- a/api.php
+++ b/api.php
@@ -135,6 +135,9 @@ function login($db, $params)
 
 function make_query($db, $sql)
 {
+    /* Initialised so a zero-row query returns [] instead of an undefined
+       variable -- reachable on any search that matches nothing. */
+    $ret = array();
     $res = db_query($sql);
     while ($row = $res->fetch()) {
         $ret[] = $row;

--- a/index.php
+++ b/index.php
@@ -179,6 +179,14 @@ function flag($quote_num, $method)
 
     $row = $db->query("SELECT id,flag,quote FROM ".db_tablename('quotes')." WHERE (flag!=3) AND id = ".$db->quote((int)$quote_num)." LIMIT 1")->fetch();
 
+    /* fetch() returns false for a missing or deleted quote, which is reachable
+       simply by requesting ?flag with no id. Every use below then indexes
+       false and a flag page is rendered for a quote that does not exist. */
+    if ($row === false) {
+	$TEMPLATE->add_message(lang('no_quote'));
+	return;
+    }
+
     if ($method == 'verdict') {
 	$ret = handle_captcha('flag', 'flag_do_inner', $row);
 	if (is_string($ret)) $TEMPLATE->add_message($ret);
@@ -201,7 +209,10 @@ function vote($quote_num, $method, $ajaxy=FALSE)
     $sql = "SELECT quote_id FROM ".db_tablename('tracking')." WHERE user_ip=".$db->quote($ip).' AND quote_id='.$db->quote((int)$quote_num);
     $qid = $db->query($sql)->fetch();
 
-    if (isset($qid) && $qid['quote_id'] == $quote_num) {
+    /* fetch() returns false when this address has not voted on this quote --
+       i.e. on every first-time vote. isset(false) is true, so the old test
+       went on to index false. */
+    if ($qid !== false && $qid['quote_id'] == $quote_num) {
 	if ($ajaxy) return 'ALREADY_VOTED';
 	$TEMPLATE->add_message(lang('tracking_check_2'));
 	return;
@@ -820,7 +831,7 @@ function userlogin($method)
 	$salt = $db->query("SELECT salt FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username'])))->fetch();
 
 	// if there is no presence of a salt, it is probably md5 since old rash used plain md5
-	if(!$salt['salt']){
+	if(!($salt !== false && $salt['salt'])){
 	    $row = $db->query("SELECT * FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username']))." AND `password` ='".md5($_POST['rash_password'])."'")->fetch();
 	}
 	// if there is presense of a salt, it is probably new rash passwords, so it is salted md5
@@ -829,7 +840,7 @@ function userlogin($method)
 	}
 
 	// if there is no row returned for the user, the password is expected to be false because of the AND conditional in the query
-	if(!$row['user']){
+	if($row === false || !$row['user']){
 	    $TEMPLATE->add_message(lang('login_error'));
 	} else {
 	    set_user_logged($row);
@@ -845,7 +856,7 @@ function adminlogin($method)
 	$salt = $db->query("SELECT salt FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username'])))->fetch();
 
 	// if there is no presence of a salt, it is probably md5 since old rash used plain md5
-	if(!$salt['salt']){
+	if(!($salt !== false && $salt['salt'])){
 	    $row = $db->query("SELECT * FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username']))." AND `password` ='".md5($_POST['rash_password'])."'")->fetch();
 	}
 	// if there is presense of a salt, it is probably new rash passwords, so it is salted md5
@@ -854,7 +865,7 @@ function adminlogin($method)
 	}
 
 	// if there is no row returned for the user, the password is expected to be false because of the AND conditional in the query
-	if(!$row['user']){
+	if($row === false || !$row['user']){
 	    $TEMPLATE->add_message(lang('login_error'));
 	} else {
 	    set_user_logged($row);
@@ -1361,10 +1372,10 @@ switch($page[0])
 		    }
 		    $query = "SELECT * FROM ".db_tablename('quotes')." WHERE (flag!=3) AND (".implode(' or ', $ids).") ORDER BY CASE id ".implode($order)." END";
 		    if ($idx > 1) $title = lang('selected_quotes');
-		    else $title = "#${_SERVER['QUERY_STRING']}";
+		    else $title = "#{$_SERVER['QUERY_STRING']}";
 		} else {
 		    $query = "SELECT * FROM ".db_tablename('quotes')." WHERE (flag!=3) AND id=".$db->quote((int)$idlist[0]);
-		    $title = "#${idlist[0]}";
+		    $title = "#{$idlist[0]}";
 		}
 		quote_generation($query, $title, -1);
 	    } else if ($_SERVER['QUERY_STRING']) {

--- a/util_funcs.php
+++ b/util_funcs.php
@@ -80,10 +80,12 @@ function set_user_logged($row)
 
 function set_user_logout()
 {
-    session_unset($_SESSION['user']);
-    session_unset($_SESSION['logged_in']);
-    session_unset($_SESSION['level']);
-    session_unset($_SESSION['userid']);
+    /* session_unset() takes no arguments and clears the entire session. PHP 7
+       ignored the extra argument; PHP 8.0 raises ArgumentCountError, making
+       logout a fatal error. These calls never did what they look like either,
+       so unset() is what was meant. */
+    unset($_SESSION['user'], $_SESSION['logged_in'],
+          $_SESSION['level'], $_SESSION['userid']);
     mk_cookie('user');
     mk_cookie('userid');
     mk_cookie('passwd');
@@ -163,14 +165,14 @@ function str_rand($length = 8, $seeds = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm
     $str = '';
     $seeds_count = strlen($seeds);
 
-    // Seed
-    list($usec, $sec) = explode(' ', microtime());
-    $seed = (float) $sec + ((float) $usec * 100000);
-    mt_srand($seed);
+    /* Not seeded by hand: mt_rand() has auto-seeded from a good source since
+       PHP 7.1, the microtime-derived value is weaker than the default for
+       something generating password salts, and casting that float to int is a
+       precision-loss deprecation on 8.1. */
 
     // Generate
     for ($i = 0; $length > $i; $i++) {
-        $str .= $seeds{mt_rand(0, $seeds_count - 1)};
+        $str .= $seeds[mt_rand(0, $seeds_count - 1)];
     }
 
     return $str;


### PR DESCRIPTION
**`master` does not parse on PHP 8.** Verified with `php -l` across the whole tree on `php:8.5-apache-trixie`: one file fails, and the same tree is clean on `php:7.3-apache-bullseye`. Nothing in this PR forces anyone off 7.x — the result lints clean on both.

Grouped because the individual fixes are small and share one cause. Happy to split if you would rather review them separately.

### Fatal on PHP 8

- **`str_rand()` used the curly-brace string offset `$seeds{...}`**, removed in 8.0. This is a *parse* error, and `index.php` requires `util_funcs.php`, so the whole site fails to load rather than degrading. It is live code — `str_rand()` generates password salts at four call sites.

- **`set_user_logout()` passed an argument to `session_unset()`**, which takes none. PHP 7 ignored extra arguments to internal functions; 8.0 raises `ArgumentCountError`, so logout returns a 500. The calls never did what they appear to either — `session_unset()` clears the *whole* session, so it was not unsetting the four named keys. Replaced with `unset()`.

### Broken output, and subtle because opcache hides it

- **Two `${var}` interpolations in `index.php`**, deprecated in 8.2. The notice is emitted at **compile time**, before the first line of the file runs, so the `ini_set('display_errors', ...)` at the top cannot suppress it. Where `display_errors` is on it prints ahead of the DOCTYPE, headers are already sent, and `session_start()` and `setcookie()` both fail.

  With opcache enabled this only happens on the **first request after each restart**, which makes it look intermittent.

### Notices on 7.x that become warnings on 8.x — all indexing a `false` fetch

- `flag()` on a missing quote id, reachable by requesting `?flag` with no id
- `vote()` on **every first-time vote** — the guard was `isset($qid)`, and `isset(false)` is true
- both login paths, user and admin, for an unknown username
- `make_query()` returned an undefined variable for any zero-row query, so an empty search produced a warning instead of `[]`

### Also

Drops the manual `mt_srand()` in `str_rand()`. `mt_rand()` has auto-seeded from a good source since 7.1, the microtime-derived value is weaker than the default for something generating password salts, and casting that float to int is a precision-loss deprecation on 8.1.
