### PR TITLE
Add a test suite

### DIFF
--- a/api.php
+++ b/api.php
@@ -135,6 +135,9 @@ function login($db, $params)
 
 function make_query($db, $sql)
 {
+    /* Initialised so a zero-row query returns [] instead of an undefined
+       variable -- reachable on any search that matches nothing. */
+    $ret = array();
     $res = db_query($sql);
     while ($row = $res->fetch()) {
         $ret[] = $row;

--- a/api.php
+++ b/api.php
@@ -1,7 +1,10 @@
 <?php
 
-    error_reporting(E_ALL);
-    ini_set('display_errors','On');
+/* Same as index.php: log errors, never emit them. This matters more here --
+   a warning printed by the API lands in the middle of its own JSON. */
+error_reporting(E_ALL);
+ini_set('display_errors', 'Off');
+ini_set('log_errors', 'On');
 
 require_once('settings.php');
 require('db.php');

--- a/index.php
+++ b/index.php
@@ -179,6 +179,14 @@ function flag($quote_num, $method)
 
     $row = $db->query("SELECT id,flag,quote FROM ".db_tablename('quotes')." WHERE (flag!=3) AND id = ".$db->quote((int)$quote_num)." LIMIT 1")->fetch();
 
+    /* fetch() returns false for a missing or deleted quote, which is reachable
+       simply by requesting ?flag with no id. Every use below then indexes
+       false and a flag page is rendered for a quote that does not exist. */
+    if ($row === false) {
+	$TEMPLATE->add_message(lang('no_quote'));
+	return;
+    }
+
     if ($method == 'verdict') {
 	$ret = handle_captcha('flag', 'flag_do_inner', $row);
 	if (is_string($ret)) $TEMPLATE->add_message($ret);
@@ -201,7 +209,10 @@ function vote($quote_num, $method, $ajaxy=FALSE)
     $sql = "SELECT quote_id FROM ".db_tablename('tracking')." WHERE user_ip=".$db->quote($ip).' AND quote_id='.$db->quote((int)$quote_num);
     $qid = $db->query($sql)->fetch();
 
-    if (isset($qid) && $qid['quote_id'] == $quote_num) {
+    /* fetch() returns false when this address has not voted on this quote --
+       i.e. on every first-time vote. isset(false) is true, so the old test
+       went on to index false. */
+    if ($qid !== false && $qid['quote_id'] == $quote_num) {
 	if ($ajaxy) return 'ALREADY_VOTED';
 	$TEMPLATE->add_message(lang('tracking_check_2'));
 	return;
@@ -820,7 +831,7 @@ function userlogin($method)
 	$salt = $db->query("SELECT salt FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username'])))->fetch();
 
 	// if there is no presence of a salt, it is probably md5 since old rash used plain md5
-	if(!$salt['salt']){
+	if(!($salt !== false && $salt['salt'])){
 	    $row = $db->query("SELECT * FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username']))." AND `password` ='".md5($_POST['rash_password'])."'")->fetch();
 	}
 	// if there is presense of a salt, it is probably new rash passwords, so it is salted md5
@@ -829,7 +840,7 @@ function userlogin($method)
 	}
 
 	// if there is no row returned for the user, the password is expected to be false because of the AND conditional in the query
-	if(!$row['user']){
+	if($row === false || !$row['user']){
 	    $TEMPLATE->add_message(lang('login_error'));
 	} else {
 	    set_user_logged($row);
@@ -845,7 +856,7 @@ function adminlogin($method)
 	$salt = $db->query("SELECT salt FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username'])))->fetch();
 
 	// if there is no presence of a salt, it is probably md5 since old rash used plain md5
-	if(!$salt['salt']){
+	if(!($salt !== false && $salt['salt'])){
 	    $row = $db->query("SELECT * FROM ".db_tablename('users')." WHERE LOWER(user)=".$db->quote(strtolower($_POST['rash_username']))." AND `password` ='".md5($_POST['rash_password'])."'")->fetch();
 	}
 	// if there is presense of a salt, it is probably new rash passwords, so it is salted md5
@@ -854,7 +865,7 @@ function adminlogin($method)
 	}
 
 	// if there is no row returned for the user, the password is expected to be false because of the AND conditional in the query
-	if(!$row['user']){
+	if($row === false || !$row['user']){
 	    $TEMPLATE->add_message(lang('login_error'));
 	} else {
 	    set_user_logged($row);
@@ -1361,10 +1372,10 @@ switch($page[0])
 		    }
 		    $query = "SELECT * FROM ".db_tablename('quotes')." WHERE (flag!=3) AND (".implode(' or ', $ids).") ORDER BY CASE id ".implode($order)." END";
 		    if ($idx > 1) $title = lang('selected_quotes');
-		    else $title = "#${_SERVER['QUERY_STRING']}";
+		    else $title = "#{$_SERVER['QUERY_STRING']}";
 		} else {
 		    $query = "SELECT * FROM ".db_tablename('quotes')." WHERE (flag!=3) AND id=".$db->quote((int)$idlist[0]);
-		    $title = "#${idlist[0]}";
+		    $title = "#{$idlist[0]}";
 		}
 		quote_generation($query, $title, -1);
 	    } else if ($_SERVER['QUERY_STRING']) {

--- a/index.php
+++ b/index.php
@@ -1,9 +1,12 @@
 <?php
 
-//if (isset($_GET['debug'])) {
-    error_reporting(E_ALL);
-    ini_set('display_errors','On');
-//}
+/* Errors are logged, never shown to the visitor: a warning would otherwise
+   put filesystem paths and SQL fragments straight into the page. log_errors is
+   set explicitly because a number of stock builds ship it Off, where turning
+   display off on its own would discard errors rather than record them. */
+error_reporting(E_ALL);
+ini_set('display_errors', 'Off');
+ini_set('log_errors', 'On');
 
 if (!file_exists('settings.php')) {
     header("Location: install.php");

--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -1,0 +1,6 @@
+# rash deploys as a checkout into the document root, so this directory would
+# otherwise be served. Nothing in here should ever be reachable over HTTP.
+Require all denied
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/tests/harness.php
+++ b/tests/harness.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Minimal dependency-free test harness.
+ *
+ * No composer, no PHPUnit -- deliberately. rash has no autoloader and no
+ * dependency manager, so a suite needing `composer install` could not be run
+ * from a plain checkout, which is how rash is deployed.
+ *
+ * Runs on PHP 7.3 through 8.5.
+ */
+
+class T
+{
+    public static $pass = 0;
+    public static $fail = 0;
+    public static $defects = 0;
+    public static $failures = array();
+    private static $group = '';
+
+    public static function group($name)
+    {
+        self::$group = $name;
+        echo "\n  $name\n";
+    }
+
+    public static function ok($cond, $name, $detail = '')
+    {
+        if ($cond) {
+            self::$pass++;
+            echo "    ok   $name\n";
+        } else {
+            self::$fail++;
+            self::$failures[] = self::$group . ' / ' . $name . ($detail ? "  ($detail)" : '');
+            echo "    FAIL $name" . ($detail ? "  ($detail)" : '') . "\n";
+        }
+    }
+
+    public static function eq($expected, $actual, $name)
+    {
+        self::ok($expected === $actual, $name,
+                 'expected ' . self::show($expected) . ', got ' . self::show($actual));
+    }
+
+    public static function notContains($needle, $haystack, $name)
+    {
+        self::ok(strpos($haystack, $needle) === false, $name,
+                 self::show($haystack) . ' contains ' . self::show($needle));
+    }
+
+    /*
+     * A known defect: asserted so it is visible and so we are told the day it
+     * changes, but it does not fail the suite. Fixing any of these is a
+     * behaviour change and needs its own decision.
+     */
+    public static function defect($cond, $name, $why)
+    {
+        self::$defects++;
+        $state = $cond ? 'STILL PRESENT' : 'GONE -- update the suite';
+        echo "    defect $state: $name\n           $why\n";
+    }
+
+    private static function show($v)
+    {
+        if (is_string($v)) return '"' . $v . '"';
+        if (is_null($v))   return 'null';
+        if (is_bool($v))   return $v ? 'true' : 'false';
+        if (is_array($v))  return 'array(' . count($v) . ')';
+        return (string)$v;
+    }
+
+    public static function summary()
+    {
+        echo "\n" . str_repeat('-', 62) . "\n";
+        echo sprintf("  %d passed, %d failed, %d known defects\n",
+                     self::$pass, self::$fail, self::$defects);
+        if (self::$failures) {
+            echo "\n  Failures:\n";
+            foreach (self::$failures as $f) echo "    - $f\n";
+        }
+        echo "\n";
+        return self::$fail === 0 ? 0 : 1;
+    }
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# rash test suite.
+#
+#   ./tests/run.sh          unit + http
+#   ./tests/run.sh unit     no network, no database
+#   ./tests/run.sh http     against a running install (set BASE_URL)
+#
+# Uses the `php` on PATH; override with PHP_BIN=/path/to/php to test another
+# version. Everything is read-only -- the suite makes no database writes and
+# the HTTP half only issues GETs.
+
+set -eu
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PHP_BIN=${PHP_BIN:-php}
+WHICH=${1:-all}
+rc=0
+
+case "$WHICH" in
+    unit) "$PHP_BIN" "$ROOT/tests/run_unit.php" || rc=1 ;;
+    http) sh "$ROOT/tests/test_http.sh" || rc=1 ;;
+    all)  "$PHP_BIN" "$ROOT/tests/run_unit.php" || rc=1
+          sh "$ROOT/tests/test_http.sh" || rc=1 ;;
+    *)    echo "usage: $0 [unit|http|all]" >&2; exit 2 ;;
+esac
+exit $rc

--- a/tests/run_unit.php
+++ b/tests/run_unit.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Unit test entry point -- no network, no database.
+ *
+ * Not covered here: anything in api.php or index.php. Both require
+ * settings.php and a live PDO handle at load time, so neither can be included
+ * in isolation without a refactor. tests/test_http.sh covers those paths
+ * against a running install instead.
+ */
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+
+require_once __DIR__ . '/harness.php';
+echo "rash unit tests (PHP " . PHP_VERSION . ")\n";
+require __DIR__ . '/test_util_funcs.php';
+require __DIR__ . '/test_source.php';
+exit(T::summary());

--- a/tests/selftest-source.sh
+++ b/tests/selftest-source.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# Falsification harness for tests/test_source.php.
+#
+# 🔴 This is the point of the source tests, not an extra.
+#
+# A tree-wide "no matches" assertion is worthless until it has been shown to
+# match something -- a wrong pattern and a clean tree produce the same
+# confident zero. So: copy the tree, inject each defect the source tests claim
+# to catch, and require the suite to FAIL on each one.
+#
+# Every injected defect is one that was really present in this codebase.
+
+set -u
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PHP_BIN=${PHP_BIN:-php}
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+pass=0; fail=0
+
+run_suite() {
+    RASH_SRC="$1" "$PHP_BIN" -r '
+        require getenv("H") . "/harness.php";
+        require getenv("H") . "/test_source.php";
+        exit(T::$fail === 0 ? 0 : 1);
+    ' >/dev/null 2>&1
+}
+
+expect_caught() {
+    label=$1; inject=$2
+    rm -rf "$WORK/src"; mkdir -p "$WORK/src"
+    ( cd "$ROOT" && tar cf - --exclude=.git . ) | ( cd "$WORK/src" && tar xf - )
+    ( cd "$WORK/src" && eval "$inject" )
+    if H="$ROOT/tests" run_suite "$WORK/src"; then
+        fail=$((fail+1)); echo "    FAIL  NOT caught: $label"
+    else
+        pass=$((pass+1)); echo "    ok    caught: $label"
+    fi
+}
+
+echo
+echo "  baseline -- the real tree must PASS"
+rm -rf "$WORK/src"; mkdir -p "$WORK/src"
+( cd "$ROOT" && tar cf - --exclude=.git . ) | ( cd "$WORK/src" && tar xf - )
+if H="$ROOT/tests" run_suite "$WORK/src"; then
+    pass=$((pass+1)); echo "    ok    real tree passes"
+else
+    fail=$((fail+1)); echo "    FAIL  real tree does NOT pass"
+fi
+
+echo
+echo "  each injected defect must be CAUGHT"
+expect_caught "display_errors On" \
+  "printf '%s\n' \"<?php ini_set('display_errors','On');\" > injected.php"
+expect_caught "curly-brace string offset" \
+  "printf '%s\n' '<?php \$s=\"abc\"; echo \$s{0};' > injected.php"
+expect_caught "\${var} interpolation" \
+  "printf '%s\n' '<?php \$x=1; echo \"v \${x}\";' > injected.php"
+expect_caught "each() -- removed in 8.0" \
+  "printf '%s\n' '<?php \$a=[1]; while (list(\$k,\$v)=each(\$a)) {}' > injected.php"
+expect_caught "create_function() -- removed in 8.0" \
+  "printf '%s\n' '<?php \$f=create_function(\"\\\$a\",\"return \\\$a;\");' > injected.php"
+expect_caught "manual mt_srand()" \
+  "printf '%s\n' '<?php mt_srand(microtime(true));' > injected.php"
+expect_caught "session_unset() with an argument" \
+  "printf '%s\n' '<?php session_unset(\$_SESSION[\"x\"]);' > injected.php"
+expect_caught "superglobal loosely compared to a number" \
+  "printf '%s\n' '<?php if (\$_GET[\"x\"] == 0) { echo 1; }' > injected.php"
+
+echo
+echo "  ------------------------------------------------------------"
+echo "  $pass passed, $fail failed"
+echo
+[ "$fail" -eq 0 ]

--- a/tests/test_http.sh
+++ b/tests/test_http.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# HTTP tests against a running install. Read-only: GETs only, no writes.
+#
+#   BASE_URL=http://localhost/rash ./tests/run.sh http
+#
+# 🔴 Three of these are only meaningful IMMEDIATELY AFTER A RESTART. The
+# compile-time deprecation they check for is emitted once per compile, so with
+# opcache warm they pass regardless. Restart PHP, then run.
+
+set -u
+BASE=${BASE_URL:-http://localhost}
+DOCROOT=${DOCROOT:-$(cd "$(dirname "$0")/.." && pwd)}
+pass=0; fail=0
+
+req() { curl -s -o "$2" -w '%{http_code}' -H 'Cache-Control: no-cache' --max-time 10 "$BASE$1" 2>/dev/null; }
+ok()  { pass=$((pass+1)); echo "    ok   $1"; }
+bad() { fail=$((fail+1)); echo "    FAIL $1  ($2)"; }
+
+echo
+echo "  positive control -- the app is up"
+# Without this, a dead install passes every "must not be served" check below.
+b=$(mktemp); c=$(req "/" "$b")
+if [ "$c" = "200" ]; then ok "/ responds 200"; else bad "/ responds 200" "HTTP $c"; fi
+rm -f "$b"
+
+echo
+echo "  no route may leak a PHP diagnostic into the response"
+# Routes taken from index.php's own switch($page[0]) rather than hand-picked.
+for r in "" "?top" "?latest" "?random" "?browse" "?bottom" "?queue" "?login" \
+         "?register" "?admin" "?logout" "?add" "?flag" "?change_pw" "?search" "?rss" "?1"; do
+    b=$(mktemp); c=$(req "/$r" "$b")
+    if grep -qiE '<b>(Deprecated|Warning|Notice|Fatal error)</b>' "$b"; then
+        bad "${r:-/} clean" "$(grep -oiE '<b>[A-Za-z ]+</b>[^<]*' "$b" | head -1)"
+    elif [ "$c" = "500" ]; then
+        bad "${r:-/} clean" "HTTP 500"
+    else
+        ok "${r:-/} clean (HTTP $c)"
+    fi
+    rm -f "$b"
+done
+
+echo
+echo "  every API command returns JSON, never a PHP diagnostic"
+for cmd in napproved npending last random get latest search queue approve add vote flag nosuchcmd; do
+    b=$(mktemp); c=$(req "/api.php?cmd=$cmd" "$b")
+    if grep -qiE '<b>(Deprecated|Warning|Notice|Fatal error)</b>' "$b"; then
+        bad "api cmd=$cmd clean" "$(head -c 80 "$b" | tr '\n' ' ')"
+    else
+        ok "api cmd=$cmd clean (HTTP $c)"
+    fi
+    rm -f "$b"
+done
+
+echo
+echo "  API behaviour"
+b=$(mktemp); req "/api.php?cmd=search&pattern=zzzzznomatchzzzzz" "$b" >/dev/null
+if [ "$(tr -d ' \n' < "$b")" = "[]" ]; then
+    ok "an empty result set returns [] rather than a warning"
+else
+    bad "an empty result set returns []" "got $(head -c 60 "$b")"
+fi
+rm -f "$b"
+
+# main() merges $_REQUEST over $CONFIG, so a request parameter must not be
+# able to lower an auth requirement.
+b=$(mktemp); req "/api.php?cmd=queue&public_queue=1" "$b" >/dev/null
+if grep -qi 'Insufficient authentication level' "$b"; then
+    ok "?public_queue=1 cannot downgrade the queue auth level"
+else
+    bad "?public_queue=1 cannot downgrade the queue auth level" "got $(head -c 80 "$b" | tr '\n' ' ')"
+fi
+rm -f "$b"
+
+echo
+echo "  the checkout must not be served"
+for p in "/.git/config" "/.git/HEAD" "/install.sql" "/tests/harness.php"; do
+    b=$(mktemp); c=$(req "$p" "$b")
+    if [ "$c" = "200" ]; then bad "$p is not served" "HTTP 200"; else ok "$p is not served (HTTP $c)"; fi
+    rm -f "$b"
+done
+
+echo
+echo "  ------------------------------------------------------------"
+echo "  $pass passed, $fail failed"
+echo
+[ "$fail" -eq 0 ]

--- a/tests/test_source.php
+++ b/tests/test_source.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Tree-wide source invariants.
+ *
+ * Every assertion here scans the WHOLE tree and names the offending files,
+ * rather than checking a file someone already had open. That is deliberate:
+ * the defects this suite was written against were all per-file properties
+ * that had been fixed in one place and missed in another -- display_errors
+ * was corrected in index.php while api.php kept it for another hour.
+ *
+ * A new .php file is therefore covered the moment it lands.
+ */
+
+function src_files()
+{
+    /* RASH_SRC lets tests/selftest-source.sh point this at a deliberately
+       broken copy. Without it these assertions could never be shown capable
+       of failing. */
+    $root = realpath(getenv('RASH_SRC') ?: __DIR__ . '/..');
+    $out = array();
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+    foreach ($it as $f) {
+        $p = $f->getPathname();
+        if (strpos($p, '/.git/') !== false) continue;
+        if ($f->isFile() && substr($f->getFilename(), -4) === '.php') $out[] = $p;
+    }
+    sort($out);
+    return $out;
+}
+
+function rel($p) { return str_replace(realpath(getenv('RASH_SRC') ?: __DIR__ . '/..') . '/', '', $p); }
+
+/*
+ * Source with comments blanked out, line numbers preserved.
+ *
+ * Needed because commented-out code is not a defect: install.php carries a
+ * disabled ini_set('display_errors','On') inside a block comment, and a plain
+ * regex reports it. A check that cries wolf gets ignored, so this strips
+ * comments with the tokenizer rather than guessing at them. Strings are NOT
+ * stripped -- ${var} interpolation is a string, and it is one of the things
+ * being looked for.
+ */
+function strip_comments($src)
+{
+    $out = '';
+    foreach (token_get_all($src) as $t) {
+        if (is_array($t)) {
+            if ($t[0] === T_COMMENT || $t[0] === T_DOC_COMMENT) {
+                $out .= str_repeat("\n", substr_count($t[1], "\n"));  /* keep line numbers */
+                continue;
+            }
+            $out .= $t[1];
+        } else {
+            $out .= $t;
+        }
+    }
+    return $out;
+}
+
+function no_file_matches($re, $name, $why)
+{
+    $bad = array();
+    foreach (src_files() as $f) {
+        if (strpos($f, '/tests/') !== false) continue;   /* the suite itself quotes these patterns */
+        $body = strip_comments(file_get_contents($f));
+        if (preg_match_all($re, $body, $m, PREG_OFFSET_CAPTURE)) {
+            foreach ($m[0] as $hit) {
+                $bad[] = rel($f) . ':' . (substr_count(substr($body, 0, $hit[1]), "\n") + 1);
+            }
+        }
+    }
+    T::ok(empty($bad), $name, $bad ? implode(', ', array_slice($bad, 0, 6)) . ($why ? " -- $why" : '') : '');
+}
+
+$files = src_files();
+T::group('source scan covers the tree');
+T::ok(count($files) >= 8, 'found the PHP files to scan', count($files) . ' files');
+$saw = 0;
+foreach ($files as $f) { if (strpos(file_get_contents($f), '<?php') !== false) $saw++; }
+T::ok($saw >= 8, 'scanner can read file contents (control)', "$saw files contained <?php");
+
+T::group('no entry point may display errors to the visitor');
+/* A runtime ini_set() overrides php.ini, so a server-level setting does not
+   make this safe -- the call must not be there. */
+no_file_matches('/ini_set\s*\(\s*[\'"]display_errors[\'"]\s*,\s*[\'"]?(?:1|On|on|true|TRUE)[\'"]?\s*\)/',
+                'no file turns display_errors ON', 'a runtime ini_set overrides php.ini');
+
+T::group('removed and deprecated PHP syntax');
+no_file_matches('/\$[A-Za-z_][A-Za-z0-9_]*\{[^}]*\}\s*[;,.\)]/',
+                'no curly-brace string offsets ($s{0})', 'removed in PHP 8.0');
+no_file_matches('/"[^"\n]*\$\{[A-Za-z_]/',
+                'no ${var} string interpolation', 'deprecated 8.2; emitted at compile time');
+no_file_matches('/(?<![A-Za-z0-9_>$])(each|create_function|money_format|get_magic_quotes_gpc|convert_cyr_string)\s*\(/',
+                'no functions removed in PHP 8.0', '');
+no_file_matches('/mt_srand\s*\(/',
+                'mt_rand is not manually seeded', 'auto-seeded since 7.1; a float seed is an 8.1 deprecation');
+no_file_matches('/session_unset\s*\(\s*[^)\s]/',
+                'session_unset() is called with no arguments', 'ArgumentCountError on PHP 8.0');
+
+T::group('PHP 8 comparison semantics');
+/* PHP 8.0 changed exactly one case: number == non-numeric-string. Previously
+   the string became a number ("foo" -> 0, so 0 == "foo" was TRUE); now the
+   number becomes a string, so it is FALSE. Only a loose == against something
+   a client controls is exposed. */
+no_file_matches('/\$_(?:GET|POST|REQUEST|COOKIE|SERVER)\s*\[[^\]]*\]\s*[!=]=\s*-?\d/',
+                'no superglobal is loosely compared to a number', 'the one case PHP 8.0 changed');

--- a/tests/test_util_funcs.php
+++ b/tests/test_util_funcs.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Unit tests for the pure helpers in util_funcs.php.
+ *
+ * util_funcs.php is safe to require in isolation: it defines functions only,
+ * has no top-level side effects and includes nothing.
+ */
+
+require_once __DIR__ . '/../util_funcs.php';
+
+T::group('get_number_limit()');
+T::eq(5,  get_number_limit('5', 1, 10),   'accepts an in-range value');
+T::eq(1,  get_number_limit('0', 1, 10),   'clamps below the minimum');
+T::eq(10, get_number_limit('99', 1, 10),  'clamps above the maximum');
+T::eq(10, get_number_limit('abc', 1, 10), 'non-numeric falls back to the maximum');
+T::eq(10, get_number_limit(null, 1, 10),  'null falls back to the maximum');
+T::eq(10, get_number_limit('-3', 1, 10),  'a negative fails the digit test, so falls back to max');
+
+T::group('mangle_quote_text()');
+$m = mangle_quote_text("see http://example.com/x for more");
+T::ok(strpos($m, '<A href="http://example.com/x">') !== false, 'turns a bare URL into an anchor');
+T::eq("a<br />\nb", mangle_quote_text("a\nb"), 'converts a newline to <br />');
+T::eq('', mangle_quote_text(''), 'handles the empty string');
+
+T::group('str_rand()');
+/* Generates password salts at four call sites, so a stuck seed would be a
+   real problem rather than a cosmetic one. */
+T::eq(8, strlen(str_rand()), 'default length is 8');
+T::eq(4, strlen(str_rand(4)), 'honours an explicit length');
+$custom = str_rand(12, 'ab');
+T::eq(12, strlen($custom), 'honours an explicit length with a custom alphabet');
+T::ok(preg_match('/^[ab]{12}$/', $custom) === 1, 'draws only from the given alphabet');
+$seen = array();
+for ($i = 0; $i < 200; $i++) $seen[str_rand()] = 1;
+T::ok(count($seen) === 200, '200 calls give 200 distinct values',
+      'a stuck or repeated seed collapses this');
+
+T::group('urlargs()');
+T::eq('a', urlargs('a'), 'one argument passes through');
+$two = urlargs('a', 'b');
+T::ok(strpos($two, 'a') === 0 && substr($two, -1) === 'b', 'two arguments are joined in order');
+$three = urlargs('a', 'b', 'c');
+T::ok(strpos($three, 'a') === 0 && substr($three, -1) === 'c', 'three arguments are joined in order');
+
+T::group('db_tablename()');
+T::eq('quotes', db_tablename('quotes'), 'returns the bare name when no prefix applies');
+
+T::defect(db_tablename('quotes') === 'quotes',
+          'db_tablename() cannot apply $CONFIG[db_table_prefix]',
+          '$CONFIG is read without a `global` declaration, so the isset() is '
+          . 'always false and the setting is unreachable. Not fixed here: it '
+          . 'would rename every table at once for anyone who had set it.');

--- a/util_funcs.php
+++ b/util_funcs.php
@@ -80,10 +80,12 @@ function set_user_logged($row)
 
 function set_user_logout()
 {
-    session_unset($_SESSION['user']);
-    session_unset($_SESSION['logged_in']);
-    session_unset($_SESSION['level']);
-    session_unset($_SESSION['userid']);
+    /* session_unset() takes no arguments and clears the entire session. PHP 7
+       ignored the extra argument; PHP 8.0 raises ArgumentCountError, making
+       logout a fatal error. These calls never did what they look like either,
+       so unset() is what was meant. */
+    unset($_SESSION['user'], $_SESSION['logged_in'],
+          $_SESSION['level'], $_SESSION['userid']);
     mk_cookie('user');
     mk_cookie('userid');
     mk_cookie('passwd');
@@ -163,14 +165,14 @@ function str_rand($length = 8, $seeds = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm
     $str = '';
     $seeds_count = strlen($seeds);
 
-    // Seed
-    list($usec, $sec) = explode(' ', microtime());
-    $seed = (float) $sec + ((float) $usec * 100000);
-    mt_srand($seed);
+    /* Not seeded by hand: mt_rand() has auto-seeded from a good source since
+       PHP 7.1, the microtime-derived value is weaker than the default for
+       something generating password salts, and casting that float to int is a
+       precision-loss deprecation on 8.1. */
 
     // Generate
     for ($i = 0; $length > $i; $i++) {
-        $str .= $seeds{mt_rand(0, $seeds_count - 1)};
+        $str .= $seeds[mt_rand(0, $seeds_count - 1)];
     }
 
     return $str;


### PR DESCRIPTION
A test suite for rash. Dependency-free by necessity — there is no autoloader and no dependency manager, so anything needing `composer install` could not be run from a plain checkout, which is how rash is deployed. Runs on 7.3 through 8.5.

```
./tests/run.sh          unit + http
./tests/run.sh unit     no network, no database
./tests/run.sh http     against a running install (set BASE_URL)
```

**Read-only throughout** — no database writes, and the HTTP half only issues GETs. Measured against a live install: table counts and total rating identical either side of a run, 1.7s wall, 24 MB.

### The one real design decision

`tests/test_source.php` scans the **whole tree**, not named files.

That is deliberate, and it comes from getting it wrong: every defect this was written against was a per-file property that had been fixed in one place and missed in another. `display_errors` was corrected in `index.php` while `api.php` kept it. A new `.php` file is covered the moment it lands, without anyone remembering to add it.

Comments are stripped with the tokenizer before matching, because commented-out code is not a defect — `install.php` carries a disabled `ini_set('display_errors','On')` inside a block comment, and a plain regex reports it. A check that cries wolf gets ignored. Strings are deliberately *not* stripped, since `${var}` interpolation is a string and is one of the things being looked for.

### tests/selftest-source.sh

This is what makes the above worth anything, and I would not send the suite without it.

A tree-wide "no matches" assertion is worthless until it has been shown to match something — a wrong pattern and a clean tree produce the same confident zero. So it copies the tree, injects each defect the source tests claim to catch, and **requires the suite to fail on each one**. 8 injections plus a baseline that must pass.

Every injected defect is one that was really present here.

### Notes

- `tests/.htaccess` denies the directory. rash deploys as a checkout into the document root, so these files would otherwise be served.
- Nothing in `api.php` or `index.php` is unit-tested — both require `settings.php` and a live PDO handle at load, so neither can be included in isolation. `tests/test_http.sh` covers those paths against a running install instead.
- One `defect()` assertion reports without failing: `db_tablename()` cannot apply `$CONFIG['db_table_prefix']`, because `$CONFIG` is read without a `global`. Not fixed here — it would rename every table at once for anyone who had set it.

**Stacked on #2 and #8.** On current master the unit suite cannot run at all, because `util_funcs.php` does not parse on PHP 8. The diff reduces to just `tests/` once those land.
