### PR TITLE
Don't show database errors to visitors

### DIFF
--- a/db.php
+++ b/db.php
@@ -6,8 +6,11 @@ function get_db($CONFIG, $TEMPLATE=NULL)
 	$db = new PDO($CONFIG['phptype'].":host=localhost;dbname=".$CONFIG['database'], $CONFIG['username'], $CONFIG['password']);
 	return $db;
     } catch (PDOException $dberror) {
+	/* The exception message names the host, the database and the
+	   username. That belongs in the log, not in the response. */
+	error_log('Database connection failed: '.$dberror->getMessage());
 	if ($TEMPLATE) $TEMPLATE->printheader('Error');
-	print $dberror->getMessage();
+	print '<p>The database is currently unavailable. Please try again later.';
 	if ($TEMPLATE) $TEMPLATE->printfooter();
 	exit;
     }
@@ -17,11 +20,13 @@ function check_db_res($res, $query=NULL)
 {
     global $db;
     if (!$res) {
-	if ($query) print '<p>Query: '.$query.'<p>';
+	/* The failing SQL and the driver message describe the schema, and on a
+	   connection-level failure the host and username too. Log them; show
+	   the visitor only that something went wrong. */
 	$err = $db->errorInfo();
-	print '<p>SQLSTATE: '. $err[0];
-	print '<p>Driver error code: '. $err[1];
-	print '<p>'.$err[2];
+	error_log('Query failed: SQLSTATE '.$err[0].' ['.$err[1].'] '.$err[2]
+		  .($query ? ' -- query: '.$query : ''));
+	print '<p>A database error occurred. Please try again later.';
 	die();
     }
 }


### PR DESCRIPTION
`check_db_res()` prints the failing SQL, the SQLSTATE and the driver message into the page before `die()`ing:

```
<p>Query: SELECT ... <p><p>SQLSTATE: 42S02<p>Driver error code: 1146<p>Table 'qdb.foo' doesn't exist
```

and `get_db()`'s catch block prints the `PDOException` message, which names the host and the database, and on an authentication failure the username. Any visitor who can provoke a query failure gets a description of the schema.

**This is independent of `display_errors`** — both use `print`, so a deployment that has turned error display off (including one that has taken #2) is still affected.

The patch logs the detail with `error_log()`, which under mod_php reaches the server's error log, and shows a generic sentence instead.

Cut from `d92bd44`, so it is independent of the other open PRs. It touches only the catch block and `check_db_res()`, not the `new PDO(...)` line that #3 and #7 change, so all three apply together. Lints clean on `php:7.3-apache-bullseye` and `php:8.5-apache-trixie`.

Verified by forcing each failure in a container and reading both halves — the response carries only the generic text, the error log carries the query and the driver message — with the pre-patch file mounted back in as the control, which produces exactly the inverse.